### PR TITLE
Renamed Faculty to Institute

### DIFF
--- a/examples/hu-kort/hu-nl.eps
+++ b/examples/hu-kort/hu-nl.eps
@@ -1,1 +1,1 @@
-../hu-nl.eps
+../../hu-nl.eps

--- a/hu.cls
+++ b/hu.cls
@@ -105,7 +105,7 @@
 \duolingual{@organisationslabel}{Organisations}{Organisaties}
 \duolingual{@datelabel}{Date}{Datum}
 \duolingual{@hu}{Utrecht University of Applied Science\\}{Hogeschool Utrecht}
-\duolingual{@fac}{Faculty of Nature and Technology}{Faculteit Natuur en Techniek}
+\duolingual{@fac}{Institute for ICT}{Instituut voor ICT}
 
 \def\@subtitle{}
 \def\@documenttype{}


### PR DESCRIPTION
The faculty of Nature and Technology does not exist anymore, renamed it to Institute for ICT.